### PR TITLE
namedRitual of Summoning can not be used

### DIFF
--- a/jie
+++ b/jie
@@ -1,0 +1,5 @@
+The problem:Dear GM,my game Account is wangjiaxi0701 and game ID is rinoar. I am warlock.One of my skills namedRitual of Summoning can not be used normally.there is invalid target on the screen，when summon my teammates. HLPE ME PLEASE! THANK YOU!!!
+
+ 
+
+GM told me to reinstalled my wow client,but it is no use,i  reinstalled my wow client twice,And then Gm told me to report this problem


### PR DESCRIPTION
The problem:Dear GM,my game Account is wangjiaxi0701 and game ID is rinoar. I am warlock.One of my skills namedRitual of Summoning can not be used normally.there is invalid target on the screen，when summon my teammates. HLPE ME PLEASE! THANK YOU!!!

GM told me to reinstalled my wow client,but it is no use,i  reinstalled my wow client twice,And then Gm told me to report this problem
